### PR TITLE
Use custom Zod resolver

### DIFF
--- a/src/forms/ZodValidationForm.jsx
+++ b/src/forms/ZodValidationForm.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { useForm } from 'react-hook-form';
-import * as z from 'zod';
-import { zodResolver } from '@hookform/resolvers/zod';
-import '../style/ZodValidationForm.css';
+import React from "react";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { customZodResolver } from "../utils/customZodResolver.js";
+import "../style/ZodValidationForm.css";
 
 const schema = z.object({
   // personal: z.object({
@@ -25,8 +26,8 @@ const schema = z.object({
         try {
           const url = new URL(val);
           return (
-            url.hostname === 'facebook.com' ||
-            url.hostname.endsWith('.facebook.com')
+            url.hostname === "facebook.com" ||
+            url.hostname.endsWith(".facebook.com")
           );
         } catch (err) {
           return false;
@@ -42,7 +43,7 @@ export const ZodValidationForm = () => {
     handleSubmit,
     formState: { errors },
   } = useForm({
-    resolver: zodResolver(schema),
+    resolver: customZodResolver(schema),
     // mode: 'onChange', // revalidtes on every input otherwise runs only upon submit
     // reValidateMode: 'onBlur', // revalidates also upon input losing focus
   });
@@ -53,24 +54,24 @@ export const ZodValidationForm = () => {
         <legend>Personal details</legend>
         <label>
           Name:
-          <input type='text' {...register('personal.name')} />
+          <input type="text" {...register("personal.name")} />
         </label>
         {errors.personal?.name && (
-          <p role='alert'>{errors.personal?.name.message}</p>
+          <p role="alert">{errors.personal?.name.message}</p>
         )}
 
         <label>
           Age:
           <input
-            type='text'
-            {...register('personal.age', {
+            type="text"
+            {...register("personal.age", {
               valueAsNumber: true,
               setValueAs: (age) => Math.round(age),
             })}
           />
         </label>
         {errors.personal?.age && (
-          <p role='alert'>{errors.personal?.age.message}</p>
+          <p role="alert">{errors.personal?.age.message}</p>
         )}
       </fieldset>
 
@@ -78,55 +79,55 @@ export const ZodValidationForm = () => {
         <legend>Company related</legend>
         <label>
           Employee ID:
-          <input type='text' {...register('company.employeeId')} />
+          <input type="text" {...register("company.employeeId")} />
         </label>
         {errors.company?.employeeId && (
-          <p role='alert'>{errors.company?.employeeId.message}</p>
+          <p role="alert">{errors.company?.employeeId.message}</p>
         )}
 
         <label>
           Employee ID 2:
           <input
-            type='text'
-            {...register('company.employeeId2', {
+            type="text"
+            {...register("company.employeeId2", {
               setValueAs: (data) =>
                 Number.isNaN(Number(data)) ? String(data) : Number(data), // employeeId2 is either a string or number. I avoided {setValueAsNumber: true} because it could return NaN if a string is passed
             })}
           />
         </label>
         {errors.company?.employeeId2 && (
-          <p role='alert'>{errors.company?.employeeId2.message}</p>
+          <p role="alert">{errors.company?.employeeId2.message}</p>
         )}
 
         <div>
           Position:
           <label>
             <input
-              type='radio'
-              {...register('company.position')}
-              value={'Director'}
+              type="radio"
+              {...register("company.position")}
+              value={"Director"}
             />
             Director
           </label>
           <label>
             <input
-              type='radio'
-              {...register('company.position')}
-              value={'Manager'}
+              type="radio"
+              {...register("company.position")}
+              value={"Manager"}
             />
             Manager
           </label>
           <label>
             <input
-              type='radio'
-              {...register('company.position')}
-              value={'Worker'}
+              type="radio"
+              {...register("company.position")}
+              value={"Worker"}
             />
             Worker
           </label>
         </div>
         {errors.company?.position && (
-          <p role='alert'>{errors.company?.position.message}</p>
+          <p role="alert">{errors.company?.position.message}</p>
         )}
       </fieldset>
 
@@ -136,33 +137,39 @@ export const ZodValidationForm = () => {
           Rating:
           <label>
             🙂
-            <input type='radio' {...register('customer.rating')} value={'🙂'} />
+            <input type="radio" {...register("customer.rating")} value={"🙂"} />
           </label>
           <label>
             😑
-            <input type='radio' {...register('customer.rating')} value={'😑'} />
+            <input type="radio" {...register("customer.rating")} value={"😑"} />
           </label>
           <label>
             🙁
-            <input type='radio' {...register('customer.rating')} value={'🙁'} />
+            <input type="radio" {...register("customer.rating")} value={"🙁"} />
           </label>
         </div>
         {errors.customer?.rating && (
-          <p role='alert'>{errors.customer.rating.message}</p>
+          <p role="alert">{errors.customer.rating.message}</p>
         )}
 
         <label>
           Email Address:
-          <input type='email' {...register('customer.email')} />
+          <input type="email" {...register("customer.email")} />
         </label>
+        {errors.customer?.email && (
+          <p role="alert">{errors.customer.email.message}</p>
+        )}
 
         <label>
           Facebook (Optional):
-          <input type='text' {...register('customer.facebookAC')} />
+          <input type="text" {...register("customer.facebookAC")} />
         </label>
+        {errors.customer?.facebookAC && (
+          <p role="alert">{errors.customer.facebookAC.message}</p>
+        )}
       </fieldset>
 
-      <input type='submit' />
+      <input type="submit" />
     </form>
   );
 };

--- a/src/utils/customZodResolver.js
+++ b/src/utils/customZodResolver.js
@@ -1,0 +1,43 @@
+export const customZodResolver = (schema) => {
+  return (values) => {
+    try {
+      const result = schema.safeParse(values);
+      if (result.success) {
+        return {
+          values: result.data,
+          errors: {},
+        };
+      } else {
+        return {
+          errors: zodToHookFormError(result.error),
+          values: {},
+        };
+      }
+    } catch (err) {
+      console.error("Resolver Error: ", err);
+      return {
+        values: {},
+        errors: {
+          root: {
+            type: "unknown",
+            message: "An unknown error occured during validation by zod",
+          },
+        },
+      };
+    }
+  };
+};
+
+export function zodToHookFormError(zodError) {
+  let errors = {};
+
+  for (const issue of zodError.issues) {
+    const path = issue.path.join(".");
+    errors[path] = {
+      type: issue.code,
+      message: issue.message,
+    };
+  }
+
+  return errors;
+}

--- a/src/utils/customZodResolver.ts
+++ b/src/utils/customZodResolver.ts
@@ -1,0 +1,48 @@
+import { FieldErrors, FieldValues, FieldError } from "react-hook-form";
+import { ZodError, ZodType } from "zod";
+
+function zodToHookFormError(zodError: ZodError): FieldErrors {
+  let errors: FieldErrors = {};
+
+  for (const issue of zodError.issues) {
+    const path = issue.path.join(".");
+    errors[path] = {
+      type: issue.code,
+      message: issue.message,
+    } as FieldError;
+  }
+
+  return errors;
+}
+
+export const customZodResolver = (
+  schema: ZodType
+): ((values: FieldValues) => { values: FieldValues; errors: FieldErrors }) => {
+  return (values) => {
+    try {
+      const result = schema.safeParse(values);
+      if (result.success) {
+        return {
+          values: result.data as FieldValues,
+          errors: {},
+        };
+      } else {
+        return {
+          errors: zodToHookFormError(result.error),
+          values: {},
+        };
+      }
+    } catch (err) {
+      console.error("Resolver Error: ", err);
+      return {
+        values: {},
+        errors: {
+          root: {
+            type: "unknown",
+            message: "An unknown error occured during validation by zod",
+          } as FieldError,
+        },
+      };
+    }
+  };
+};


### PR DESCRIPTION
Bug fix: Create a `customZodResolver()` to convert the zod values and errors into hook form compatible values and errors. The `zodResolver()` from react-hook-form fails to catch zod errors which are thown uncaught to the console.