### PR TITLE
Better use of `useWatch()`

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { ConditionalFieldGroupFromFieldArray } from "./forms/ConditionalFieldGroupFromFieldArray";
+import { ConditionalFieldFromFieldArray } from "./forms/ConditionalFieldFromFieldArray";
 // import { ZodExptForm } from './forms/ZodExptForm';
 // import { ExptForm } from './forms/ExptForm';
 import "./style/AllForms.css";
@@ -6,7 +6,7 @@ import "./style/AllForms.css";
 const App = () => {
   return (
     <>
-      <ConditionalFieldGroupFromFieldArray />
+      <ConditionalFieldFromFieldArray />
       {/* <ZodExptForm /> */}
       {/* <ExptForm /> */}
     </>

--- a/src/forms/ConditionalFieldFromFieldArray.jsx
+++ b/src/forms/ConditionalFieldFromFieldArray.jsx
@@ -1,3 +1,8 @@
+// DIFFERENCE BETWEEN ConditionalFieldGroupFromFieldArray & ConditionalFieldFromFieldArray file:
+// ConditionalFieldGroupFromFieldArray - demonstrates a bunch of visible fields stored in state at the top level
+// ConditionalFieldFromFieldArray - demonstrates rendering an extra field, conditionally, below an always-rendered field, basing on the current value of that field
+// (Use better naming next time or create separate file with new code)
+
 import { useForm, useFieldArray, useWatch } from "react-hook-form";
 
 // [{id: 123, field1: "a"}, {id: 456, field1: "b"}] -> field groups (array)
@@ -24,7 +29,7 @@ export const ConditionalFieldFromFieldArray = () => {
     <form onSubmit={handleSubmit((d) => console.log(d))}>
       {fieldGroupsArray.map((fieldGroup, index) => (
         <div key={fieldGroup.id}>
-          <ConditionalField
+          <ConditionalFieldGroup
             control={control}
             register={register}
             index={index}
@@ -37,32 +42,23 @@ export const ConditionalFieldFromFieldArray = () => {
   );
 };
 
-const ConditionalField = ({ control, register, index }) => {
-  const fieldGroupsArray = useWatch({
+const ConditionalFieldGroup = ({ control, register, index }) => {
+  const conditionalField = useWatch({
     control,
-    name: "fieldGroupsArray",
+    name: `fieldGroupsArray.${index}.conditionalField`, // watch specific field value instead of whole array to prevent unnecessary re-renders of this component by useWatch() when other field values change
   });
 
   return (
     <>
-      {fieldGroupsArray[index]?.conditionalField === "test1" && ( // only conditionally render <input>s for particular fieldGroups
+      <input {...register(`fieldGroupsArray.${index}.conditionalField`)} />
+      {conditionalField === "test1" && ( // only conditionally render <input>s / extra fields  basing on the value of a particular field
         <input
           type="text"
-          {...register(`fieldGroupsArray.${index}.conditionalField`)} // connect / register this <input> to that 2nd object in the fieldGroupsArray such that any changes to it may be made via this <input>
+          {...register(
+            `fieldGroupsArray.${index}.extraFieldBasedOnConditionalFieldValue`
+          )} // connect / register this <input> to that 2nd object in the fieldGroupsArray such that any changes to it may be made via this <input>
         />
       )}
-      {/* OR: */}
-      <input
-        type="text"
-        s
-        {...register(`fieldGroupsArray.${index}.conditionalField`)}
-        style={{
-          display:
-            fieldGroupsArray[index]?.conditionalField === "test1"
-              ? "block"
-              : "none",
-        }}
-      />
     </>
   );
 };

--- a/src/forms/ConditionalFieldGroupFromFieldArray.jsx
+++ b/src/forms/ConditionalFieldGroupFromFieldArray.jsx
@@ -1,3 +1,8 @@
+// DIFFERENCE BETWEEN ConditionalFieldGroupFromFieldArray & ConditionalFieldFromFieldArray file:
+// ConditionalFieldGroupFromFieldArray - demonstrates a bunch of visible fields stored in state at the top level
+// ConditionalFieldFromFieldArray - demonstrates rendering an extra field, conditionally, below an always-rendered field, basing on the current value of that field
+// (Use better naming next time or create separate file with new code)
+
 import { useState } from "react";
 import { useForm, useFieldArray, useWatch } from "react-hook-form";
 
@@ -63,6 +68,10 @@ export const ConditionalFieldGroupFromFieldArray = () => {
   );
 };
 
+// For this simple example, instead of using useWatch() and conditionally rendering inputs using shouldShow, I would have just rendered <ConditionalField /> inside <form> basing on visibleFields!
+// However, the extracting the logic below is especially useful when using:
+// 1. <Controller> with controlled components + useWatch() to watch the array efficiently (prevents unnecessary re-renders)
+// 2. When rendering/ registering <input> that's deeply nested, hence passing visibleFields via props might be ambiguous
 const ConditionalField = ({ control, register, index, visibleFields }) => {
   const fieldGroup = useWatch({
     control,


### PR DESCRIPTION
Performance Bug fix: watch over a specific field value instead of the whole FieldArray using `useWatch()` to prevent unnecessary rerenders

Add comments to clarify the purpose of the code in each file